### PR TITLE
Mock eyes.checkWindow when there is no API KEY

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function _init() {
   } else {
     eyes.it = eyesWithout(it);
     eyes.fit = eyesWithout(fit);
-    eyes.checkWindow = ()=> Promise.resolve();
+    eyes.checkWindow = () => Promise.resolve();
   }
 
   eyes.defaultWindowSize = null;

--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ function _init() {
   } else {
     eyes.it = eyesWithout(it);
     eyes.fit = eyesWithout(fit);
+    eyes.checkWindow = ()=> Promise.resolve();
   }
 
   eyes.defaultWindowSize = null;


### PR DESCRIPTION
This fix allows e2e tests to run locally without failing.
See issue #11 

I tested manually (and locally only), by using `npm link` from another project.